### PR TITLE
Changing the install order + engine version.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,12 +7,6 @@
     "build": "next build",
     "start": "next start"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "dependencies": {
     "axios": "^0.24.0",
     "eslint": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "This full-stack application depicting a regular library collection has been created as a programming exercise for recruit purposes.",
   "main": "server/dist/index.js",
   "engines": {
-    "node": "12.19.0"
+    "node": "12.14.1"
   },
   "scripts": {
     "start:production": "npm --prefix ./server/ start",
     "start:dev": "concurrently --kill-others -c cyan,magenta -n CLIENT,SERVER \"cd client/ && npm run dev\" \"npm --prefix ./server/ run dev\"",
     "front:install:build": "cd client/ && npm i && npm run build",
     "server:install:compile": "cd server && npm i && npm run compile",
-    "preinstall": "npm run front:install:build",
-    "postinstall": "npm run server:install:compile"
+    "preinstall": "npm run server:install:compile",
+    "postinstall": "npm run front:install:build"
   },
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.ts",
   "engines": {
-    "node": "12.19.0"
+    "node": "12.14.1"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=production node dist/index.js",


### PR DESCRIPTION
Heroku can't make a cached version of the client, because it doesn't have access to the API. This is most likely because frontend is built first, so this PR seeks to change the API around to be built and deployed first.